### PR TITLE
Fetch remote branches to enable branch name parsing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -104,6 +104,7 @@ jobs:
       script:
         - export BRANCH_TAG=${TRAVIS_BRANCH}-$(git rev-parse --short ${TRAVIS_COMMIT})
         - git clone --single-branch --branch=gh-pages https://github.com/lamalex/liftright-data-server.git output
+        - echo "Removing ${PBRANCH}*.json"
         - rm -f output/${PBRANCH}*.json
         - pipenv run python bench-tags.py --runs=1 --on-tag=${BRANCH_TAG} --output=output
       after_script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -93,13 +93,16 @@ jobs:
           mv wrk ~/bin &&
           cd ..
       install:
-        - git clone https://launibot:${GH_TOKEN}@github.com/LiftRight/lrds-bench
+        - git config --replace-all remote.origin.fetch +refs/heads/*:refs/remotes/origin/*
+        - git fetch
         - |
           PSHA=$(git cat-file -p ${TRAVIS_COMMIT} |grep parent |tail -n1 |cut -d ' ' -f2) &&
-          PBRANCH=$(git name-rev --name-only ${PSHA})
+          PBRANCH=$(git name-rev --name-only ${PSHA} |cut -d '/' -f3)
+        - git clone https://launibot:${GH_TOKEN}@github.com/LiftRight/lrds-bench
         - cd lrds-bench
-        - docker-compose -f mongo-compose.yaml up -d
         - pipenv install
+      before_script:
+        - docker-compose -f mongo-compose.yaml up -d
       script:
         - export BRANCH_TAG=${TRAVIS_BRANCH}-$(git rev-parse --short ${TRAVIS_COMMIT})
         - git clone --single-branch --branch=gh-pages https://github.com/lamalex/liftright-data-server.git output


### PR DESCRIPTION
git name-rev will only give relation to current branch if branch refs
are not available. Updating remote refs allow name-rev to pull out the
merged branch's name
